### PR TITLE
Bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@
 # BOLOS_SDK NOT DEFINED		We use a containerized build approach
 # containerize build is recommended
 
+APPVERSION_M = 1
+APPVERSION_N = 0
+APPVERSION_P = 2
+
 NANOS_ID = 1
 WORDS = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 PIN = 5555

--- a/MakefileLocal.mk
+++ b/MakefileLocal.mk
@@ -20,9 +20,6 @@ $(error Environment variable BOLOS_SDK is not set)
 endif
 
 APPNAME      = "FIO"
-APPVERSION_M = 1
-APPVERSION_N = 0
-APPVERSION_P = 1
 APPVERSION   = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 APPPATH = "44'/235'"
 

--- a/MakefileTest.mk
+++ b/MakefileTest.mk
@@ -24,7 +24,9 @@ TESTS_SPECULOS_DIR=test-integration
 define run_nodejs_test
 	@cd $(TESTS_SPECULOS_DIR) \
 	&& { { { \
-          TEST_SPECULOS_API_PORT=$(1) TEST_SPECULOS_APDU_PORT=$(2) TEST_DEVICE=$(TEST_DEVICE) node $(3) 2>&1; echo $$? >&3; \
+          TEST_SPECULOS_API_PORT=$(1) TEST_SPECULOS_APDU_PORT=$(2) TEST_DEVICE=$(TEST_DEVICE) \
+          APPVERSION_M=$(APPVERSION_M) APPVERSION_N=$(APPVERSION_N) APPVERSION_P=$(APPVERSION_P) \
+          node $(3) 2>&1; echo $$? >&3; \
         } | tee -a ../speculos-port-$(1).log >&4; } 3>&1 | { read xs; exit $$xs; } } 4>&1
 endef
 

--- a/ledgerjs-fio/package.json
+++ b/ledgerjs-fio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledgerjs-hw-app-fio",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "files": [
     "dist"
   ],

--- a/test-integration/getVersion.js
+++ b/test-integration/getVersion.js
@@ -17,9 +17,9 @@ await device.makeStartingScreenshot();
 
 testStep(" - - -", "await app.runTests()");
 const {version, compatibility} = await app.getVersion();
-assert.equal(version.major, 1)
-assert.equal(version.minor, 0)
-assert.equal(version.patch, 1)
+assert.equal(version.major, parseInt(process.env.APPVERSION_M))
+assert.equal(version.minor, parseInt(process.env.APPVERSION_N))
+assert.equal(version.patch, parseInt(process.env.APPVERSION_P))
 assert.equal(compatibility.isCompatible, true)
 assert.equal(compatibility.recommendedVersion, null)
 


### PR DESCRIPTION
Bump version.
Move version constants to the main Makefile. These constants now enter tests so one does not need to modify tests